### PR TITLE
add enum entry for ARCHIVED because mailchimp uses it

### DIFF
--- a/src/main/java/com/github/alexanderwe/bananaj/model/list/member/MemberStatus.java
+++ b/src/main/java/com/github/alexanderwe/bananaj/model/list/member/MemberStatus.java
@@ -11,7 +11,8 @@ package com.github.alexanderwe.bananaj.model.list.member;
  */
 public enum MemberStatus {
 
-	PENDING("pending"),SUBSCRIBED("subscribed"),UNSUBSCRIBED("unsubscribed"),CLEANED("cleaned"),TRANSACTIONAL("transactional");
+	PENDING("pending"),SUBSCRIBED("subscribed"),UNSUBSCRIBED("unsubscribed"),CLEANED("cleaned"),TRANSACTIONAL("transactional"),
+  ARCHIVED("archived");
 	
 	private String stringRepresentation;
 	


### PR DESCRIPTION
Thanks for your wrapper library, as it helped me interface with the pretty confusing MailChimp API (in hindsight mainly because of multiple names for objects in the model). Got an exception during my testing so I added this missing status, and then looked for any others mentioned in documentation but this seems to be only one AFAIK.